### PR TITLE
vim: Add test running indicator to statusline

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -56,7 +56,7 @@ vim.diagnostic.config({
 vim.api.nvim_create_autocmd('CursorMoved', {
     pattern = '*',
     callback = function()
-        vim.diagnostic.open_float(nil, { focus = false, scope = 'line', border = 'rounded', header = '' })
+        vim.diagnostic.open_float(nil, { focus = false, scope = 'line', border = 'rounded', header = '', source = 'always' })
     end,
 })
 

--- a/nvim/lua/plugins/lualine.lua
+++ b/nvim/lua/plugins/lualine.lua
@@ -40,7 +40,26 @@ return {
                     "filename",
                 },
 
-                lualine_x = {},
+                lualine_x = {
+                    {
+                        function()
+                            -- Check all buffers for running test signs
+                            for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+                                if vim.api.nvim_buf_is_loaded(bufnr) then
+                                    local signs = vim.fn.sign_getplaced(bufnr, { group = "neotest-status" })
+                                    for _, sign_list in ipairs(signs) do
+                                        for _, sign in ipairs(sign_list.signs or {}) do
+                                            if sign.name == "neotest_running" then
+                                                return "Testing 🔄"
+                                            end
+                                        end
+                                    end
+                                end
+                            end
+                            return ""
+                        end,
+                    },
+                },
 
                 lualine_y = {},
 

--- a/nvim/lua/plugins/neotest.lua
+++ b/nvim/lua/plugins/neotest.lua
@@ -41,6 +41,13 @@ return {
                 },
             })
 
+            -- Strip ANSI codes from neotest diagnostics
+            vim.diagnostic.config({
+                format = function(diagnostic)
+                    return diagnostic.message:gsub('\27%[[0-9;]*m', '')
+                end,
+            }, vim.api.nvim_create_namespace("neotest"))
+
             -- Create an autocommand to save files before neotest runs tests
             vim.api.nvim_create_autocmd("User", {
                 pattern = "NeotestPre*",


### PR DESCRIPTION
## Summary
• Adds a dynamic indicator in the statusline that shows "Testing 🔄" when tests are running
• Uses neotest signs to detect running test status across all loaded buffers  
• Strips ANSI escape codes from neotest diagnostic messages for improved readability
• Integrates seamlessly with existing lualine configuration

## Test plan
- [ ] Run tests and verify the "Testing 🔄" indicator appears in the statusline
- [ ] Verify indicator disappears when tests complete
- [ ] Test with multiple buffers to ensure detection works globally
- [ ] Verify that diagnostic messages from failing tests no longer contain escape sequences

🤖 Generated with [Claude Code](https://claude.ai/code)